### PR TITLE
Modify float parser

### DIFF
--- a/src-lib/Parser/Parse.hs
+++ b/src-lib/Parser/Parse.hs
@@ -36,7 +36,7 @@ signedDouble = L.signed spaceConsumer float
     float = lexeme L.decimal
 
 floatingNum :: Parser Double
-floatingNum = L.float
+floatingNum = L.signed spaceConsumer L.float
 
 parseNumber :: Parser Expression
 parseNumber = Number <$> (try floatingNum <|> signedDouble)


### PR DESCRIPTION
This PR modifies the floating point number parser to include negative numbers.
Closing https://github.com/paritosh-08/calc-haskell/issues/4