### PR TITLE
use Data.Ratio instead of Double

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,14 +7,16 @@ import Calculator.Calculate
 import Calculator.Types
 import Parser.Parse
 
-myEXP = 
+myEXP =
   Operator Add (Number 5) (Operator Sub (Operator Mult (Number 0) (Operator Div (Operator Add (Number 1) (Number 7)) (Number 0))) (Number 2))
 
 main :: IO ()
 main = do
   putStrLn "Enter an expression:"
   e <- getLine
-  case runParser parseExpression "input" e of 
+  case runParser parseExpression "input" e of
     Left err -> putStrLn (errorBundlePretty err)
     Right expr' -> do
-      print $ eval expr'
+      case eval expr' of
+        Left ce -> error (show ce)
+        Right (x0, x1) ->putStrLn $ show x0 ++ " = " ++ show (fromRational x0)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -21,7 +21,7 @@ eval3 expr' = case eval expr' of
 
 main :: IO ()
 main = do
-  putStrLn "Enter an expression:"
+  putStrLn "Enter an expression :"
   e <- getLine
   case runParser parseExpression "input" e of
     Left err -> putStrLn (errorBundlePretty err)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,9 +6,18 @@ import Text.Megaparsec
 import Calculator.Calculate
 import Calculator.Types
 import Parser.Parse
+import Data.Ratio
 
 myEXP =
   Operator Add (Number 5) (Operator Sub (Operator Mult (Number 0) (Operator Div (Operator Add (Number 1) (Number 7)) (Number 0))) (Number 2))
+
+eval2 expr' = case eval expr' of
+        Left ce -> error (show ce)
+        Right (x0, x1) -> show x0 ++ " ≈ " ++ show (fromRational x0)
+
+eval3 expr' = case eval expr' of
+        Left ce -> error (show ce)
+        Right (x0, x1) -> show (fromRational x0)
 
 main :: IO ()
 main = do
@@ -16,7 +25,16 @@ main = do
   e <- getLine
   case runParser parseExpression "input" e of
     Left err -> putStrLn (errorBundlePretty err)
-    Right expr' -> do
-      case eval expr' of
-        Left ce -> error (show ce)
-        Right (x0, x1) ->putStrLn $ show x0 ++ " = " ++ show (fromRational x0)
+    Right expr' -> putStrLn $ eval2 expr'
+
+x = SQR (Number (132329094442 % 1943931730431))
+y = SQR (Number (5277604304397 % 4408623464236))
+z = Operator Pow (Number (10453572296738 % 8383466229469)) (Number (12753708597271 % 6634025500147))
+-- >>> eval3 (Operator Mult (Operator Pow x y) (Operator Pow x z))
+-- "2.949125184606776e-2"
+
+-- >>> eval3 (Operator Pow x (Operator Add y z))
+-- "2.9491251846067757e-2"
+
+-- >>> (eval3 x, eval3 y, eval3 z)
+-- ("0.26090786194179927","1.0941249175460188","1.5284511470724913")

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -21,7 +21,7 @@ eval3 expr' = case eval expr' of
 
 main :: IO ()
 main = do
-  putStrLn "Enter an expression :"
+  putStrLn "Enter an expression:"
   e <- getLine
   case runParser parseExpression "input" e of
     Left err -> putStrLn (errorBundlePretty err)

--- a/src-lib/Parser/Parse.hs
+++ b/src-lib/Parser/Parse.hs
@@ -7,6 +7,7 @@ import qualified Text.Megaparsec.Char as M
 import qualified Text.Megaparsec.Char.Lexer as L
 
 import Calculator.Types
+import Data.Ratio
 
 type Parser a = Parsec Void String a
 
@@ -38,8 +39,19 @@ signedDouble = L.signed spaceConsumer float
 floatingNum :: Parser Double
 floatingNum = L.signed spaceConsumer L.float
 
+fractionalNum :: Parser Rational
+fractionalNum = do
+  num <- signedDouble <* spaceConsumer
+  _ <- symbol "%" <* spaceConsumer
+  den <- signedDouble
+  pure (round num % round den)
+
+
 parseNumber :: Parser Expression
-parseNumber = Number <$> (try floatingNum <|> signedDouble)
+parseNumber =  try 
+      (Number . toRational <$> floatingNum )
+  <|> (try (Number <$> fractionalNum)
+  <|> (Number . toRational <$> signedDouble))
 
 parens :: Parser a -> Parser a
 parens = between (symbol "(") (symbol ")")

--- a/src-test/Main.hs
+++ b/src-test/Main.hs
@@ -46,7 +46,15 @@ prop_add_fail_comm (BadExpr x) (BadExpr y) = eval (Operator Add x y) === eval (O
 
 -- TODO : handle nonzero z, failing - decimal digits don't match (after 7-8 places)
 prop_div_ratio :: Expression -> Expression -> Expression -> Property
-prop_div_ratio x y z = eval (Operator Div x y) === eval (Operator Div (Operator Div x z) (Operator Div y z)) -- (x/y) = ((x/z) / (y/z))
+prop_div_ratio x' y' z' =
+  let
+    (Right (x'',_)) = eval x'
+    (Right (y'',_)) = eval y'
+    (Right (z'',_)) = eval z'
+    (x,y,z) = if z'' /= 0
+      then (Number x'',Number y'',Number z'')
+      else (Number x'',Number y'',Number 1.0)
+  in eval (Operator Div x y) === eval (Operator Div (Operator Div x z) (Operator Div y z)) -- (x/y) = ((x/z) / (y/z))
   -- z /= 0 ==> eval (Operator Div x y) === eval (Operator Div (Operator Div x z) (Operator Div y z))
 
 -- Number (-0.2527207028827523)
@@ -56,14 +64,13 @@ prop_div_ratio x y z = eval (Operator Div x y) === eval (Operator Div (Operator 
 prop_prod_of_pow :: Expression -> Expression -> Expression -> Property 
 prop_prod_of_pow x y z = eval (Operator Mult (Operator Pow x y) (Operator Pow x z)) === eval (Operator Pow x (Operator Add y z)) -- Property -> (x^y)(x^z) = x^(y+z)
 
--- decimal digits don't match (after 7-8 places)
 prop_sqrt_prod :: Expression -> Expression -> Property
 prop_sqrt_prod x' y' = 
   let
     (Right (x'',_)) = eval x'
     (Right (y'',_)) = eval y'
     (x,y) = 
-      if (x'' < 0) && (y'' < 0)
+      if (x'' <= 0) && (y'' <= 0)
       then
         let
           x = Number (abs x'')
@@ -74,7 +81,13 @@ prop_sqrt_prod x' y' =
           x = x'
           y = y'
         in (x,y)
-  in eval (Operator Mult (SQR x) (SQR y)) === eval (SQR (Operator Mult x y)) -- Property -> (sqrt x)(sqrt y) = (sqrt x*y)
+    exp1 = case eval (Operator Mult (SQR x) (SQR y)) of
+      Left ce -> Left ce
+      Right (x3,x4) -> Right (fromRational x3, x4)
+    exp2 = case eval (SQR (Operator Mult x y)) of
+      Left ce -> Left ce
+      Right (x3,x4) -> Right (fromRational x3, x4)
+  in exp1 === exp2 -- Property -> (sqrt x)(sqrt y) = (sqrt x*y)
 
 prop_pretty_parse_round_trip :: Expression -> Property
 prop_pretty_parse_round_trip exp = case runParser parseExpression "inp" (pretty exp) of
@@ -83,7 +96,7 @@ prop_pretty_parse_round_trip exp = case runParser parseExpression "inp" (pretty 
 
 main :: IO ()
 main = do
-  sample (arbitrary @Double)
+  -- sample (arbitrary @Double)
   -- sample (resize 1 $ arbitrary @Expression)
   -- sample (resize 2 $ arbitrary @Expression)
   quickCheckWith (stdArgs) prop_add_comm                  -- ✓
@@ -92,6 +105,6 @@ main = do
   quickCheckWith (stdArgs) prop_mul_asso                  -- ✓
   quickCheckWith (stdArgs) prop_distribu                  -- ✓
   quickCheckWith (stdArgs) prop_div_ratio                 -- ✓
-  quickCheckWith (stdArgs) prop_prod_of_pow               -- ❌
-  quickCheckWith (stdArgs) prop_sqrt_prod                 -- ❌
+  verboseCheckWith (stdArgs) prop_prod_of_pow               -- ❌
+  verboseCheckWith (stdArgs) prop_sqrt_prod                 -- ❌
   quickCheckWith (stdArgs) prop_pretty_parse_round_trip   -- ✓

--- a/src-test/Main.hs
+++ b/src-test/Main.hs
@@ -88,10 +88,10 @@ main = do
   -- sample (resize 2 $ arbitrary @Expression)
   quickCheckWith (stdArgs) prop_add_comm                  -- ✓
   quickCheckWith (stdArgs) prop_mul_comm                  -- ✓
-  quickCheckWith (stdArgs) prop_add_asso                  -- ❌
-  quickCheckWith (stdArgs) prop_mul_asso                  -- ❌
-  quickCheckWith (stdArgs) prop_distribu                  -- ❌
-  quickCheckWith (stdArgs) prop_div_ratio                 -- ❌
+  quickCheckWith (stdArgs) prop_add_asso                  -- ✓
+  quickCheckWith (stdArgs) prop_mul_asso                  -- ✓
+  quickCheckWith (stdArgs) prop_distribu                  -- ✓
+  quickCheckWith (stdArgs) prop_div_ratio                 -- ✓
   quickCheckWith (stdArgs) prop_prod_of_pow               -- ❌
   quickCheckWith (stdArgs) prop_sqrt_prod                 -- ❌
   quickCheckWith (stdArgs) prop_pretty_parse_round_trip   -- ✓


### PR DESCRIPTION
This PR changes the representation of number in calculator.
Using Rational instead of Double will result in more precision.

Closing https://github.com/paritosh-08/calc-haskell/issues/7